### PR TITLE
FIX: fix inter-lang link (#8)

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -28,9 +28,12 @@
     <div class="container">
       <div class="i18n align-items-center">
         <ul>
-{% for support_lang in site.languages %}
-        <li{% if support_lang == site.active_lang %} class="active"{% endif %}>
-          <a {% static_href %}href="{% if support_lang == site.default_lang %}{{site.baseurl}}{{page.url}}{% else %}{{site.baseurl}}/{{support_lang}}{{page.url}}{% endif %}"{% endstatic_href %}>{{ site.data.languages[support_lang] }}</a>
+{% for lang_code in site.languages %}
+  {% if lang_code == site.default_lang %}{% assign lang_href = site.baseurl | append: page.url | replace: "//", "/" %}
+  {% else %}{% assign lang_href = site.baseurl | append: lang_code | append: page.url | replace: "//", "/"  %}
+  {% endif %}
+        <li{% if lang_code == site.active_lang %} class="active"{% endif %}>
+          <a href="{{ lang_href }}">{{ site.data.languages[lang_code] }}</a>
         </li>
         {%- if forloop.last == false -%}<li>{{" "}}{{ site.langsep }}{{" "}}</li>{%- endif -%}
 {% endfor %}

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -29,11 +29,12 @@
       <div class="i18n align-items-center">
         <ul>
 {% for lang_code in site.languages %}
-  {% if lang_code == site.default_lang %}{% assign lang_href = site.baseurl | append: page.url | replace: "//", "/" %}
-  {% else %}{% assign lang_href = site.baseurl | append: lang_code | append: page.url | replace: "//", "/"  %}
+  {% if lang_code == site.default_lang %}{% assign lang_href = site.baseurl | append: page.url | relative_url | replace: "//", "/" %}
+  {% else %}{% assign lang_href = site.baseurl | append: lang_code | append: page.url | relative_url | replace: "//", "/"  %}
   {% endif %}
         <li{% if lang_code == site.active_lang %} class="active"{% endif %}>
-          <a href="{{ lang_href }}">{{ site.data.languages[lang_code] }}</a>
+          {% if lang_code == site.active_lang %}<span>{{ site.data.languages[lang_code] }}</span>
+          {% else %}<a href="{{ lang_href }}">{{ site.data.languages[lang_code] }}</a>{% endif %}
         </li>
         {%- if forloop.last == false -%}<li>{{" "}}{{ site.langsep }}{{" "}}</li>{%- endif -%}
 {% endfor %}


### PR DESCRIPTION

다국어 지원을 하며 언어간 이동 링크를 잘못 지정했던 것을 수정합니다.

한국어 상태에서의 링크
![image](https://user-images.githubusercontent.com/9343724/229541295-29d51e69-3b12-4de9-b960-7b5bd6b6f16e.png)

영어 상태에서의 링크
![image](https://user-images.githubusercontent.com/9343724/229541502-0e42a389-95ff-4a43-a217-fdb74afd7cb9.png)
