### PR TITLE
행동강령(CoC) 링크 오류 해결

### DIFF
--- a/_data/en/translations.yml
+++ b/_data/en/translations.yml
@@ -25,4 +25,4 @@ includes:
     social:
       heading: Social
       description: Find us on other services!
-    coc: The Cloud Bandwagon and those who be with us adhere to a <a href="{{ site.ext_links.coc }}" target="_blank">Code of Conduct</a>.
+    coc: The Cloud Bandwagon and those who be with us adhere to a <a href="__COC_URL__" target="_blank">Code of Conduct</a>.

--- a/_data/ko/translations.yml
+++ b/_data/ko/translations.yml
@@ -25,4 +25,4 @@ includes:
     social:
       heading: 유랑단 소식
       description: 더 많은 곳에서 클라우드 유랑단을 만나보세요!
-    coc: 클라우드 유랑단 및 유랑단과 함께 하는 모든 사람들은 <a href="{{ site.ext_links.coc }}" target="_blank">행동 강령</a>을 준수합니다.
+    coc: 클라우드 유랑단 및 유랑단과 함께 하는 모든 사람들은 <a href="__COC_URL__" target="_blank">행동 강령</a>을 준수합니다.

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -41,7 +41,7 @@
         </ul>
       </div>
       <div class="copyright">
-        <p class="footer-links">{{ translations.includes.footer.coc }}</p>
+        <p class="footer-links">{{ translations.includes.footer.coc | replace: "__COC_URL__", site.ext_links.coc }}</p>
         &copy; Copyright <strong><span>{{ translations.site.title }}</span></strong>. All Rights Reserved.
       </div>
       <div class="credits">


### PR DESCRIPTION

CoC 링크에서 참조하고 있는 `{{ site.ext_links.coc }}`를 파싱하지 못해 발생하는 문제(#14)를 해결합니다.

우선 해당 링크를 `__COC_URL__`로 적어두고, html로 빌드될 때 `site.ext_links.coc`의 값으로 치환하도록 임시 조치하였습니다.

장기적으로는 `.github`에 있는 CoC를 submodule로 추가하여 빌드 시 홈페이지 내부의 문서로 빌드되게 해야 합니다.